### PR TITLE
Add libgen-cli v1.0.5

### DIFF
--- a/Casks/libgen-cli.rb
+++ b/Casks/libgen-cli.rb
@@ -1,0 +1,11 @@
+cask 'libgen-cli' do
+  version '1.0.5'
+  sha256 '835c8c8776e175485403f5fd64a871526831504dde40080957f85e316b560b1b'
+
+  url "https://github.com/ciehanski/libgen-cli/releases/download/v#{version}/libgen-cli-v#{version}-darwin"
+  appcast 'https://github.com/ciehanski/libgen-cli/releases.atom'
+  name 'libgen-cli'
+  homepage 'https://github.com/ciehanski/libgen-cli'
+
+  binary "libgen-cli-v#{version}-darwin", target: 'libgen'
+end


### PR DESCRIPTION
This PR adds libgen-cli version 1.0.5 to homebrew.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
